### PR TITLE
Add --time flag to see total execution time

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -29,7 +29,7 @@ def socket_file
 end
 
 # ## spin serve
-def serve(force_rspec = false)
+def serve(force_rspec = false, time = false)
   file = socket_file
   # We delete the tmp file for the Unix socket if it already exists. The file
   # is scoped to the `pwd`, so if it already exists then it must be from an
@@ -68,6 +68,10 @@ def serve(force_rspec = false)
     files = conn.gets.chomp
     files = files.split(File::PATH_SEPARATOR)
 
+    # If spin is started with the time flag we will track total execution so
+    # you can easily compare it with time rspec spec for example
+    start = Time.now if time
+
     # We fork(2) before loading the file so that our pristine preloaded
     # environment is untouched. The child process will load whatever code it
     # needs to, then it exits and we're back to the baseline preloaded app.
@@ -94,6 +98,10 @@ def serve(force_rspec = false)
     # that destroys the idea of being simple to use. So we wait(2) until the
     # child process has finished running the test.
     Process.wait
+
+    # If we are tracking time we will output it here after everything has
+    # finished running
+    puts "Total execution time was #{Time.now - start} seconds" if start
   end
 end
 
@@ -120,6 +128,7 @@ rescue Errno::ECONNREFUSED
 end
 
 force_rspec = false
+time = false
 options = OptionParser.new do |opts|
   opts.banner = usage
   opts.separator ""
@@ -135,6 +144,10 @@ options = OptionParser.new do |opts|
 
   opts.on('-e', 'Stub to keep kicker happy')
 
+  opts.on('-t', '--time') do |v|
+    time = true
+  end
+
   opts.on('-h', '--help') do
     $stderr.puts opts
     exit 1
@@ -144,7 +157,7 @@ options.parse!
 
 subcommand = ARGV.shift
 case subcommand
-when 'serve' then serve(force_rspec)
+when 'serve' then serve(force_rspec, time)
 when 'push' then push
 else
   $stderr.puts options

--- a/bin/spin
+++ b/bin/spin
@@ -50,7 +50,7 @@ def serve(force_rspec = false)
       # In my experience that's the best we can do in terms of preloading. Rails
       # and the gem dependencies rarely change and so don't need to be reloaded.
       # But you can't initialize the application because any non-trivial app will
-      # involve it's models/controllers, etc. in its initialization, which you 
+      # involve it's models/controllers, etc. in its initialization, which you
       # definitely don't want to preload.
       require File.expand_path 'config/application'
     }
@@ -79,7 +79,7 @@ def serve(force_rspec = false)
       # test file that you want to run (suddenly test/unit seems like the less
       # crazy one!).
       if defined?(RSpec) || force_rspec
-        # We pretend the filepath came in as an argument and duplicate the 
+        # We pretend the filepath came in as an argument and duplicate the
         # behaviour of the `rspec` binary.
         ARGV.push files
         require 'rspec/autorun'
@@ -102,7 +102,7 @@ def push
   # This is the other end of the socket that `spin serve` opens. At this point
   # `spin serve` will accept(2) our connection.
   socket = UNIXSocket.open(socket_file)
-  # The filenames that we will spin up to `spin serve` are passed in as 
+  # The filenames that we will spin up to `spin serve` are passed in as
   # arguments.
   files_to_load = ARGV
 


### PR DESCRIPTION
I wanted the option to compare the time it took my tests to run with `time rspec spec` so I could see how much I was actually winning with this gem, I think other people would like to know as well so that's why I turned it into a pullrequest.

I tried to honor your coding style but please let me know if anything needs more work.
