### PR TITLE
Preload rspec with the server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Or push multiple files to be loaded at once:
 spin push test/unit/product_test.rb test/unit/shop_test.rb test/unit/cart_test.rb
 ```
 
+Or, when using RSpec, run the whole suite:
+
+``` bash
+spin push spec
+```
+
 If you experience issues with `test_helper.rb` not being available you may need to add your test directory to the load path using the `-I` option:
 
 ``` bash
@@ -74,7 +80,7 @@ How did I load the ActiveRecord gem over 2000 times in one week? Autotest. I was
 
 Given that there's no way to compile Ruby code into a faster representation I immediately thought of fork(2). I just need a process to load up Rails and wait around until I need it. When I want to run the tests I just fork(2) that idle process and run the test. Then I only have to load Rails once at the start of my workflow, fork(2) takes care of sharing the code with each child process.
 
-I threw together the first version of this project in about 20 minutes and noticed an immediate difference in the speed of my testing workflow. Did I mention that I work on a big app? It takes about 10 seconds(!) to load Rails and all of the gem dependencies. With a bit more hacking I was able to get the idle process to load both Rails and my application dependencies, so each test run just initializes the application and loads the files needed for the test run. 
+I threw together the first version of this project in about 20 minutes and noticed an immediate difference in the speed of my testing workflow. Did I mention that I work on a big app? It takes about 10 seconds(!) to load Rails and all of the gem dependencies. With a bit more hacking I was able to get the idle process to load both Rails and my application dependencies, so each test run just initializes the application and loads the files needed for the test run.
 
 (10 seconds saved per test run) x (2000 test runs per week) = (lots of time saved!)
 

--- a/bin/spin
+++ b/bin/spin
@@ -46,10 +46,6 @@ end
 
 # ## spin serve
 def serve(force_rspec, force_testunit, time, push_results)
-  # Determine the test framework to use using the passed-in 'force' options
-  # or else default to checking for defined constants.
-  test_framework = determine_test_framework(force_rspec, force_testunit)
-
   file = socket_file
 
   # We delete the tmp file for the Unix socket if it already exists. The file
@@ -61,6 +57,8 @@ def serve(force_rspec, force_testunit, time, push_results)
   socket = UNIXServer.open(file)
 
   ENV['RAILS_ENV'] = 'test' unless ENV['RAILS_ENV']
+
+  test_framework = nil
 
   if File.exist? 'config/application.rb'
     sec = Benchmark.realtime {
@@ -76,8 +74,12 @@ def serve(force_rspec, force_testunit, time, push_results)
       # definitely don't want to preload.
       require File.expand_path 'config/application'
 
-      # This saves several seconds on each test run
-      ['rspec', 'rspec/rails'].each do |gem|
+      # Determine the test framework to use using the passed-in 'force' options
+      # or else default to checking for defined constants.
+      test_framework = determine_test_framework(force_rspec, force_testunit)
+
+      # Preload RSpec to save some time on each test run
+      ['rspec', 'rspec/rails', 'rspec/autorun'].each do |gem|
         begin
           require gem
         rescue LoadError
@@ -131,7 +133,6 @@ def serve(force_rspec, force_testunit, time, push_results)
         # We pretend the filepath came in as an argument and duplicate the
         # behaviour of the `rspec` binary.
         ARGV.push files
-        require 'rspec/autorun'
       else
         # We require the full path of the file here in the child process.
         files.each { |f| require File.expand_path f }

--- a/bin/spin
+++ b/bin/spin
@@ -46,11 +46,17 @@ end
 
 # ## spin serve
 def serve(force_rspec, force_testunit, time, push_results)
+  # Determine the test framework to use using the passed-in 'force' options
+  # or else default to checking for defined constants.
+  test_framework = determine_test_framework(force_rspec, force_testunit)
+
   file = socket_file
+
   # We delete the tmp file for the Unix socket if it already exists. The file
   # is scoped to the `pwd`, so if it already exists then it must be from an
   # old run of `spin serve` and can be cleaned up.
   File.delete(file) if File.exist?(file)
+
   # This socket is how we communicate with `spin push`.
   socket = UNIXServer.open(file)
 
@@ -69,6 +75,15 @@ def serve(force_rspec, force_testunit, time, push_results)
       # involve it's models/controllers, etc. in its initialization, which you
       # definitely don't want to preload.
       require File.expand_path 'config/application'
+
+      # This saves several seconds on each test run
+      ['rspec', 'rspec/rails'].each do |gem|
+        begin
+          require gem
+        rescue LoadError
+          # do nothing
+        end
+      end if test_framework == :rspec
     }
     # This is the amount of time that you'll save on each subsequent test run.
     puts "Preloaded Rails env in #{sec}s..."
@@ -89,7 +104,7 @@ def serve(force_rspec, force_testunit, time, push_results)
     # If spin is started with the time flag we will track total execution so
     # you can easily compare it with time rspec spec for example
     start = Time.now if time
-    
+
     # If we're not sending results back to the push process, we can disconnect
     # it immediately.
     disconnect(conn) unless push_results
@@ -99,7 +114,7 @@ def serve(force_rspec, force_testunit, time, push_results)
     # needs to, then it exits and we're back to the baseline preloaded app.
     fork do
       # To push the test results to the push process instead of having them
-      # displayed by the server, we reopen $stdout/$stderr to the open 
+      # displayed by the server, we reopen $stdout/$stderr to the open
       # connection.
       if push_results
         $stdout.reopen(conn)
@@ -108,10 +123,6 @@ def serve(force_rspec, force_testunit, time, push_results)
 
       puts
       puts "Loading #{files.inspect}"
-
-      # Determine the test framework to use using the passed-in 'force' options
-      # or else default to checking for defined constants.
-      test_framework = determine_test_framework(force_rspec, force_testunit)
 
       # Unfortunately rspec's interface isn't as simple as just requiring the
       # test file that you want to run (suddenly test/unit seems like the less
@@ -136,7 +147,7 @@ def serve(force_rspec, force_testunit, time, push_results)
     # If we are tracking time we will output it here after everything has
     # finished running
     puts "Total execution time was #{Time.now - start} seconds" if start
-    
+
     # Tests have now run. If we were pushing results to a push process, we can
     # now disconnect it.
     begin
@@ -222,3 +233,4 @@ else
   $stderr.puts options
   exit 1
 end
+


### PR DESCRIPTION
I added a short code that preloads rspec in the serve function. On my box, when specing with RSpec, it results in a 4-5 seconds speed up on each test run, which I think is worth it.

I also added a short description to the documentation explaining how to run the whole test suite. This was unclear to me when I was first reading the docs.

And, BTW, thanks for your work, Spin works great for me so far.
