### PR TITLE
Rspec line filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Or, when using RSpec, run the whole suite:
 spin push spec
 ```
 
+You can also specify line numbers when using RSpec:
+
+``` bash
+spin push spec/models/car.rb:123
+```
+
 If you experience issues with `test_helper.rb` not being available you may need to add your test directory to the load path using the `-I` option:
 
 ``` bash

--- a/bin/spin
+++ b/bin/spin
@@ -14,7 +14,9 @@ require 'digest/md5'
 require 'benchmark'
 require 'optparse'
 
-
+# This class is responsible for handling a file specifier's various
+# representations. Currently it only accounts for a filename and a line number
+# filter (used by RSpec)
 class SpinFile
   attr_accessor :filename
   attr_accessor :line_filter
@@ -27,6 +29,8 @@ class SpinFile
     @line_filter = file_specifier.split(":")[1]
   end
 
+  # Would output spec/models/user.rb:123 if a line is specified when
+  # constructed
   def to_s
     @filename + (@line_filter ? ":#{@line_filter}" : "")
   end

--- a/bin/spin
+++ b/bin/spin
@@ -125,7 +125,7 @@ def serve(force_rspec, force_testunit, time, push_results)
     conn = socket.accept
     # This should be a list of relative paths to files.
     files = conn.gets.chomp
-    files = files.split(File::PATH_SEPARATOR)
+    files = files.split(SpinFile::PATH_SEPARATOR).map { |fs| SpinFile.new(fs) }
 
     # If spin is started with the time flag we will track total execution so
     # you can easily compare it with time rspec spec for example
@@ -179,10 +179,10 @@ def fork_and_run(files, push_results, test_framework)
     if test_framework == :rspec
       # We pretend the filepath came in as an argument and duplicate the
       # behaviour of the `rspec` binary.
-      ARGV.push files
+      ARGV.push files.map(&:to_s)
     else
       # We require the full path of the file here in the child process.
-      files.each { |f| require File.expand_path f }
+      files.each { |f| require File.expand_path f.filename }
     end
 
   end
@@ -193,14 +193,14 @@ end
 def push
   # The filenames that we will spin up to `spin serve` are passed in as
   # arguments.
-  files_to_load = ARGV
+  files_to_load = ARGV.map { |file_specifier| SpinFile.new(file_specifier) }
 
   # We reject anything in ARGV that isn't a file that exists. This takes
   # care of scripts that specify files like `spin push -r file.rb`. The `-r`
   # bit will just be ignored.
   #
   # We build a string like `file1.rb:file2.rb` and pass it up to the server.
-  f = files_to_load.select { |f| File.exist?(f) }.uniq.join(File::PATH_SEPARATOR)
+  f = files_to_load.select { |f| File.exist?(f.filename) }.uniq.join(SpinFile::PATH_SEPARATOR)
   abort if f.empty?
   puts "Spinning up #{f}"
 

--- a/bin/spin
+++ b/bin/spin
@@ -14,6 +14,24 @@ require 'digest/md5'
 require 'benchmark'
 require 'optparse'
 
+
+class SpinFile
+  attr_accessor :filename
+  attr_accessor :line_filter
+
+  PATH_SEPARATOR = File::PATH_SEPARATOR * 2
+
+  # A file specifier can be a path or a path:line_number (for RSpec)
+  def initialize(file_specifier)
+    @filename    = file_specifier.split(":")[0]
+    @line_filter = file_specifier.split(":")[1]
+  end
+
+  def to_s
+    @filename + (@line_filter ? ":#{@line_filter}" : "")
+  end
+end
+
 def usage
   <<-USAGE
 Usage: spin serve


### PR DESCRIPTION
Enables an understanding of RSpec line number filters when specified via `spin push`. With other test frameworks, line specifiers are ignored.
