### PR TITLE
Support running single RSpec example with line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Or, when using RSpec, run the whole suite:
 spin push spec
 ```
 
+Running a single RSpec example by adding a line number is also possible, e.g:
+
+``` bash
+spin push spec/models/user_spec.rb:14
+```
+
 If you experience issues with `test_helper.rb` not being available you may need to add your test directory to the load path using the `-I` option:
 
 ``` bash

--- a/bin/spin
+++ b/bin/spin
@@ -14,6 +14,8 @@ require 'digest/md5'
 require 'benchmark'
 require 'optparse'
 
+SEPARATOR = '|'
+
 def usage
   <<-USAGE
 Usage: spin serve
@@ -107,7 +109,7 @@ def serve(force_rspec, force_testunit, time, push_results)
     conn = socket.accept
     # This should be a list of relative paths to files.
     files = conn.gets.chomp
-    files = files.split(File::PATH_SEPARATOR)
+    files = files.split(SEPARATOR)
 
     # If spin is started with the time flag we will track total execution so
     # you can easily compare it with time rspec spec for example
@@ -181,8 +183,8 @@ def push
   # care of scripts that specify files like `spin push -r file.rb`. The `-r`
   # bit will just be ignored.
   #
-  # We build a string like `file1.rb:file2.rb` and pass it up to the server.
-  f = files_to_load.select { |f| File.exist?(f) }.uniq.join(File::PATH_SEPARATOR)
+  # We build a string like `file1.rb|file2.rb` and pass it up to the server.
+  f = files_to_load.select { |f| File.exist?(f.split(':')[0]) }.uniq.join(SEPARATOR)
   abort if f.empty?
   puts "Spinning up #{f}"
 


### PR DESCRIPTION
Makes it possible for RSpec users to run a single example by adding a line number.

I think we need this feature now, and can add code to allow for running test cases by name (for testunit users) later.
