### PR TITLE
Run selected unit/test by test_name - issue #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Or push multiple files to be loaded at once:
 spin push test/unit/product_test.rb test/unit/shop_test.rb test/unit/cart_test.rb
 ```
 
+Or push selected test by name (executed as -n '/test_newproduct/')
+
+``` bash
+spin push test/unit/product_test.rb:test_newproduct
+```
+
 Or, when using RSpec, run the whole suite:
 
 ``` bash

--- a/bin/spin
+++ b/bin/spin
@@ -170,7 +170,15 @@ def fork_and_run(files, push_results, test_framework, conn)
       ARGV.push files
     else
       # We require the full path of the file here in the child process.
-      files.each { |f| require File.expand_path f }
+      # Run only selected test by name.
+      # Add -n with all given names as Regexp eg. /name1|name2|name3/
+      names = "/#{files.map{|f|f.split(':')[1]}.reject(&:nil?).join('|')}/"
+      unless names == '//'
+        ARGV << '-n'
+        ARGV << names
+        puts "Test names: #{names}"
+      end
+      files.each { |f| require File.expand_path f.split(':')[0] }
     end
 
   end


### PR DESCRIPTION
for example:

```
spin push test/unit/account_test.rb:test_sometest
```

will set -n in ARGV with value regexp '/test_sometest/' before requiring given test files. 

also works for many files but not exactly correct:

```
spin push test/unit/account_test.rb:name1 test/unit/shop_test.rb:name2
```

is ok, but:

```
spin push test/unit/account_test.rb:name1 test/unit/shop_test.rb
```

just run only one test from account_test.rb named "name1"
