### PR TITLE
kicker-2.5.0 spin push compatibility

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -195,7 +195,20 @@ def push
   # bit will just be ignored.
   #
   # We build a string like `file1.rb|file2.rb` and pass it up to the server.
-  f = files_to_load.select { |f| File.exist?(f.split(':')[0].to_s) }.uniq.join(SEPARATOR)
+  f = files_to_load.collect do |f|  
+    f = f.split(':')[0].to_s
+    if File.exist?(f)
+      f    # default behavior
+    elsif File.extname(f).length == 0 #file without extension
+      f = "#{f}.rb" # try .rb extension
+      if File.exist?(f)
+        f    
+      else 
+        nil #fallback to default behavior
+      end  
+    end  
+  end.compact.uniq.join(SEPARATOR)
+
   abort if f.empty?
   puts "Spinning up #{f}"
 


### PR DESCRIPTION
kicker-2.5.0 signals test files without .rb extensions and that was causing spin push to fail.

for example error i faced on rails3.2.1 + kicker-2.5.0: 
13:46:18.29 | Executing: spin push -I. -r test/functional/messages_controller_test -e ''
13:46:18.45 | Failed (256)

this problem is fixed with this commit, which keeps the default behavior intact and adds fallback checks for .rb files

So, no more spin push failures.
example output after fix:
16:05:28.89 | Executing: spin push -I. -r test/functional/messages_controller_test -e ''
Spinning up test/functional/messages_controller_test.rb
