### PR TITLE
Adds Errno:ENOENT to the exceptions list on socket opening

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -254,7 +254,7 @@ def push
     break if line[-1,1] == "\0"
     print line
   end
-rescue Errno::ECONNREFUSED
+rescue Errno::ECONNREFUSED, Errno::ENOENT
   abort "Connection was refused. Have you started up `spin serve` yet?"
 end
 


### PR DESCRIPTION
Since we delete socket after closing spin, error Errno::ENOENT appears while we trying to push file to the spin (and spin is not stated).
I've added ENOENT to the rescue exceptions list, so instead of the stack trace we see a regular message "Connection was refused. Have you started up spin serve yet?"

fixes the #42 issue.
