### PR TITLE
Fix broken link in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ There's another project ([spork](https://github.com/sporkrb/spork)) that aims to
 
     Spin should work out of the box with any Rails app. No custom configuration required.
 
-3. It doesn't do any [crazy monkey patching](https://github.com/sporkrb/spork/blob/master/lib/spork/app_framework/rails.rb#L43-80).
+3. It doesn't do any [crazy monkey patching](https://github.com/sporkrb/spork-rails/blob/master/lib/spork/app_framework/rails.rb#L43-80).
 
 Docs
 ============


### PR DESCRIPTION
Link to [sporkrb/spork-rails](https://github.com/sporkrb/spork-rails) instead of [sporkrb/spork](https://github.com/sporkrb/spork) when giving an example of its "crazy monkey patching".

This is because Spork has recently had its Rails support extracted out into a separate gem, called `spork-rails`. As a consequence of this, the `lib/spork/app_framework/rails.rb` file has been moved with it, leaving behind a broken link in spin's  README.
