### PR TITLE
Passing trailing arguments to test runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 docs/
 spec/tmp
+tags

--- a/lib/spin.rb
+++ b/lib/spin.rb
@@ -14,6 +14,7 @@ module Spin
   extend Spin::Hooks
 
   PUSH_FILE_SEPARATOR = '|'
+  ARGS_SEPARATOR = ' -- '
 
   class << self
     def serve(options)
@@ -50,18 +51,20 @@ module Spin
       abort if files_to_load.empty?
 
       puts "Spinning up #{files_to_load.join(" ")}"
-      send_files_to_serve(files_to_load)
+      send_files_to_serve(files_to_load, options[:trailing_pushed_args] || [])
     end
 
     private
 
-    def send_files_to_serve(files_to_load)
+    def send_files_to_serve(files_to_load, trailing_args)
       # This is the other end of the socket that `spin serve` opens. At this point
       # `spin serve` will accept(2) our connection.
       socket = UNIXSocket.open(socket_file)
 
       # We put the filenames on the socket for the server to read and then load.
-      socket.puts files_to_load.join(PUSH_FILE_SEPARATOR)
+      payload = files_to_load.join(PUSH_FILE_SEPARATOR)
+      payload += "#{ARGS_SEPARATOR}#{trailing_args.join(PUSH_FILE_SEPARATOR)}" unless trailing_args.empty?
+      socket.puts payload
 
       while line = socket.readpartial(100)
         break if line[-1,1] == "\0"
@@ -120,6 +123,8 @@ module Spin
       conn = socket.accept
       # This should be a list of relative paths to files.
       files = conn.gets.chomp
+      files, trailing_args = files.split(ARGS_SEPARATOR)
+      options[:trailing_args] = trailing_args.nil? ? [] : trailing_args.split(PUSH_FILE_SEPARATOR)
       files = files.split(PUSH_FILE_SEPARATOR)
 
       # If spin is started with the time flag we will track total execution so
@@ -155,7 +160,7 @@ module Spin
     # TODO test this
     def rerun_last_tests_on_quit(options)
       trap('QUIT') do
-        fork_and_run(@last_files_ran, nil, options)
+        fork_and_run(@last_files_ran, nil, options.merge(trailing_args: @last_trailing_args_used))
         Process.wait
       end
     end
@@ -266,6 +271,12 @@ module Spin
         puts
         puts "Loading #{files.inspect}"
 
+        trailing_args = options[:trailing_args]
+        puts "Will run with: #{trailing_args}" unless trailing_args.empty?
+
+        # Pass any additional push arguments to the test runner
+        trailing_args.each {|a| ARGV.push a }
+
         # Unfortunately rspec's interface isn't as simple as just requiring the
         # test file that you want to run (suddenly test/unit seems like the less
         # crazy one!).
@@ -279,6 +290,7 @@ module Spin
         end
       end
       @last_files_ran = files
+      @last_trailing_args_used = options[:trailing_args]
     end
 
     def socket_file

--- a/lib/spin.rb
+++ b/lib/spin.rb
@@ -186,7 +186,7 @@ module Spin
         options[:test_framework] ||= determine_test_framework
 
         # Preload RSpec to save some time on each test run
-        if options[:test_framework]
+        if options[:test_framework] == :rspec
           begin
             require 'rspec/autorun'
 

--- a/lib/spin/cli.rb
+++ b/lib/spin/cli.rb
@@ -27,6 +27,13 @@ module Spin
           opts.on("-e", "Stub to keep kicker happy")
           opts.on("-v", "--version", "Show Version") { puts Spin::VERSION; exit }
           opts.on("-h", "--help") { $stderr.puts opts; exit }
+          opts.on('--', 'Separates trailing arguments to be forwarded to  the test runner') do |v|
+            trailing_pushed_args = []
+            while opt = ARGV.shift
+              trailing_pushed_args << opt
+            end
+            options[:trailing_pushed_args] = trailing_pushed_args
+          end
         end
         parser.parse!
 

--- a/lib/spin/cli.rb
+++ b/lib/spin/cli.rb
@@ -18,8 +18,8 @@ module Spin
             $LOAD_PATH.concat(dirs.split(File::PATH_SEPARATOR))
           end
 
-          opts.on("--rspec", "Force the selected test framework to RSpec") { options[:test_framework] = :testunit }
-          opts.on("--test-unit", "Force the selected test framework to Test::Unit") { options[:test_framework] = :rspec }
+          opts.on("--rspec", "Force the selected test framework to RSpec") { options[:test_framework] = :rspec }
+          opts.on("--test-unit", "Force the selected test framework to Test::Unit") { options[:test_framework] = :testunit }
           opts.on("-t", "--time", "See total execution time for each test run") { options[:time] = true }
           opts.on("--push-results", "Push test results to the push process") { options[:push_results] = true }
           opts.on("--preload FILE", "Preload this file instead of #{options[:preload]}") { |v| options[:preload] = v }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -142,6 +142,19 @@ describe "Spin" do
         served.should include "BBB"
         served.should_not include "CCC"
       end
+
+      it "can pass trailing arguments to the spec runner" do
+        write "spec/foo_spec.rb", <<-RUBY
+          describe "x" do
+            it("a"){ puts "AAA" }
+            it("b"){ puts "BBB" }
+            it("c"){ puts "CCC" }
+          end
+        RUBY
+        served, pushed = serve_and_push("", ["spec/foo_spec.rb -- --profile"])
+        served.should include 'Will run with: ["--profile"]'
+        served.should include 'Top 3 slowest examples'
+      end
     end
 
     context "options" do
@@ -188,6 +201,12 @@ describe "Spin" do
       it "can show total execution time" do
         served, pushed = serve_and_push("--time", ["test/foo_test.rb", "test/foo_test.rb"])
         served.should include "Total execution time was 0."
+        pushed.first.should == @default_pushed
+      end
+
+      it "can pass trailing arguments to the test runner" do
+        served, pushed = serve_and_push("", ["test/foo_test.rb -- -n /validates/"])
+        served.should include 'Will run with: ["-n", "/validates/"]'
         pushed.first.should == @default_pushed
       end
     end


### PR DESCRIPTION
Pushing all the args after -- to ARGV before test unit file is required.
