### PR TITLE
Fix an issue with files_to_load containing nil and duplicate values

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -201,14 +201,13 @@ end
 def push
   # The filenames that we will spin up to `spin serve` are passed in as
   # arguments.
-  files_to_load = ARGV
-
+  #
   # We reject anything in ARGV that isn't a file that exists. This takes
   # care of scripts that specify files like `spin push -r file.rb`. The `-r`
   # bit will just be ignored.
   #
   # We build a string like `file1.rb|file2.rb` and pass it up to the server.
-  files_to_load.map! do |file|
+  files_to_load = ARGV.map do |file|
     args = file.split(':')
 
     file_name = args.first.to_s


### PR DESCRIPTION
I encountered an issue where `files_to_load` was:

```
[nil, nil, "spec/requests/foo_spec.rb"]
```

Given the following from ARGV:

```
["spec/controllers/foo_controller_spec.rb", "spec/requests/api/v1/foo_spec.rb", "spec/requests/foo_spec.rb"]
```

(The first two files, of course, didn't exist.)

This pull request fixes it.
