### PR TITLE
Fix nil error when used together with kicker

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -214,7 +214,7 @@ def push
   # bit will just be ignored.
   #
   # We build a string like `file1.rb|file2.rb` and pass it up to the server.
-  files_to_load.map! do |file|
+  files_to_load = files_to_load.map do |file|
     args = file.split(':')
 
     file_name = args.first.to_s


### PR DESCRIPTION
When using spin together with kicker as advertised in the README, the following error may happen:

```
spin:237:in `initialize': can't convert nil into String (TypeError)
```

This change fixes an in-place `map!` operation so that the subsequent `compact` and `uniq` actually have an effect. This strips `nil` arguments that are the result of passing empty strings to `spin` on the command line.
