### PR TITLE
Fix cleaning of `files_to_load` array.

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -236,7 +236,7 @@ def push
     else
       file_name
     end
-  end.compact.uniq
+  end.compact!.uniq!
 
   if root_path = rails_root
     files_to_load.map! do |file|


### PR DESCRIPTION
Once `files_to_load` was called with `map!`, the calls to `compact` and `uniq` no longer had any effect. This caused errors such as:

```
    .../.gem/gems/spin-0.4.6/bin/spin:237:in `initialize': can't convert nil into String (TypeError)
        from /Users/rusty/.gem/gems/spin-0.4.6/bin/spin:237:in `new'
        from /Users/rusty/.gem/gems/spin-0.4.6/bin/spin:237:in `block in push'
        from /Users/rusty/.gem/gems/spin-0.4.6/bin/spin:236:in `map!'
        from /Users/rusty/.gem/gems/spin-0.4.6/bin/spin:236:in `push'
        from /Users/rusty/.gem/gems/spin-0.4.6/bin/spin:302:in `<top (required)>'
        from /Users/rusty/.gem/bin/spin:19:in `load'
        from /Users/rusty/.gem/bin/spin:19:in `<main>'
```

Fixed by changing to `compact!` and `uniq!`.
