### PR TITLE
"require 'rspec/rails'" causes load order problems

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -102,7 +102,6 @@ def serve(force_rspec, force_testunit, time, push_results, preload)
 
       # Preload RSpec to save some time on each test run
       begin
-        require 'rspec/rails'
         require 'rspec/autorun'
 
         # Tell RSpec it's running with a tty to allow colored output


### PR DESCRIPTION
Hi - I've been having problems with the inclusion of helpers in view specs, when run via spin.  I'm wondering if the routes issue (https://github.com/jstorimer/spin/issues/36) is a similar problem.

AFAICT, the problem boils down to :  ActionView::TestCase::TestController will not include your helpers when spin is used, if you're relying on ActionController::Base.include_all_helpers to include them for you.  (The problem is covered up slightly by Rspec auto-including certain modules - so if you have a 'posts/index' view spec, rspec will include PostsHelper automatically.  So the problem is only obvious if you're relying on methods in FooHelper inside your 'posts' view file)

When run via rspec, we get this order of events:
- Rails loads and registers its initializers
- The application initializes, firing the initializer hooks, resulting in ActionController::Railties::Paths inserting an 'inherited' hook
- rspec-rails loads ActionView::TestCase (from HelperExampleGroup), thus defining ActionView::TestCase::TestController.  The 'inherited' hook automatically includes all helpers into ActionView::TestCase::TestController.

Under spin, however, we get this order of events:
- Rails loads and registers its initializers
- rspec-rails loads ActionView::TestCase (from HelperExampleGroup), thus defining ActionView::TestCase::TestController.
- 'spin push foo' causes the application to initialize, firing the initializer hooks.  ActionController::Railties::Paths inserts an 'inherited' hook, but it's too late for ActionView::TestCase::TestController.

In case those ramblings didn't make sense, I uploaded a quick rails app to https://github.com/jdelStrother/spin-view-fail.  You can generate an error with "spin push spec/views/posts/index.html.erb_spec.rb", due to the missing helper methods.

The easiest fix is to not run "require 'rspec/rails'" in the preloader, though obviously you're then wasting time on each 'spin push'.  This can be mitigated somewhat by carefully cherry-picking what to require in the preload - for instance, "require 'action_controller/base'" is safe (as far as I can tell...), and in our app saves about 0.5s per 'spin push'.

As an added bonus, removing "require 'rspec/rails'" from the preloader also fixes missing routing methods (https://github.com/jstorimer/spin/issues/36), at least in our app.

This pull request removes 'rspec/rails', but doesn't go so far as to start loading ActionController::Base.  Any opinions on preloading that and/or other sections of rails?
