### PR TITLE
Fix the case where file_name is nil.

### DIFF
--- a/lib/spin.rb
+++ b/lib/spin.rb
@@ -101,7 +101,7 @@ module Spin
 
           "#{file_name}:#{line_number}"
         else
-          file_name
+          file_name.to_s
         end
       end.reject(&:empty?).uniq
     end


### PR DESCRIPTION
This can happen on line 96, causing line 106 to blow up:

```
/Users/tyson/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bundler/gems/spin-110b19cdd888/lib/spin.rb:112:in `reject': undefined method `empty?' for nil:NilClass (NoMethodError)
  from /Users/tyson/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bundler/gems/spin-110b19cdd888/lib/spin.rb:112:in `convert_push_arguments_to_files'
  from /Users/tyson/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bundler/gems/spin-110b19cdd888/lib/spin.rb:41:in `push'
  from /Users/tyson/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bundler/gems/spin-110b19cdd888/lib/spin/cli.rb:36:in `run'
  from /Users/tyson/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bundler/gems/spin-110b19cdd888/bin/spin:3:in `<top (required)>'
  from /Users/tyson/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bin/spin:23:in `load'
  from /Users/tyson/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/bin/spin:23:in `<main>'
```
