### PR TITLE
Do not make ARGV a 2d Array

### DIFF
--- a/lib/spin.rb
+++ b/lib/spin.rb
@@ -272,7 +272,7 @@ module Spin
         if options[:test_framework] == :rspec
           # We pretend the filepath came in as an argument and duplicate the
           # behaviour of the `rspec` binary.
-          ARGV.push files
+          ARGV.concat files
         else
           # We require the full path of the file here in the child process.
           files.each { |f| require File.expand_path f }


### PR DESCRIPTION
When I put a `binding.pry` into my spin-controlled tests, I was getting failures stemming from seeing `ARGV`s that looked like: 

```
[["spec/features/job_applications_spec.rb"]]
```

This patch makes sure not to make double-Arrays
