### PR TITLE
Option to strip ansi color output when using --push-results

### DIFF
--- a/lib/spin/cli.rb
+++ b/lib/spin/cli.rb
@@ -22,6 +22,7 @@ module Spin
           opts.on("--test-unit", "Force the selected test framework to Test::Unit") { options[:test_framework] = :testunit }
           opts.on("-t", "--time", "See total execution time for each test run") { options[:time] = true }
           opts.on("--push-results", "Push test results to the push process") { options[:push_results] = true }
+          opts.on("--strip-ansi-color", "Remove ansi color escaping sequences, useful when using --push-results") { options[:strip_ansi_color] = true }
           opts.on("--preload FILE", "Preload this file instead of #{options[:preload]}") { |v| options[:preload] = v }
           opts.separator "General Options:"
           opts.on("-e", "Stub to keep kicker happy")


### PR DESCRIPTION
Thanks for spin, work great. But I see ugly ansi escape sequences in my RubyTest console in Sublime. I recognized that it`s not a problem with RubyTest but with the raw output from spin. So I tried to fix it in spin- with success. A simple regex just before sending the results back will clear the escape sequences. Available through a new CLI option "--strip-ansi-color".

BUT: See the problem description at the end, option is not passed yet. 

```
spin serve --push-results --strip-ansi-color
```

Here the working fix

``` ruby
#spin.rb line 74
while line = socket.readpartial(100)
  break if line[-1,1] == "\0"
  if strip_ansi_color
    #clear ansi escape sequences
    line = line.gsub(/\e\[[^m]*m/, '')
  end
  print line
end
```

Only one problem: I was not able to figure out how to pass options to from spin server to spin push when forked. All options are lost after forking and only the default parameter preload:true is left in method #push.
Maybe somebody can look into this ? The fix itself is working. Screens before and after attached.

![screen shot 2013-06-05 at 11 53 14](https://f.cloud.github.com/assets/1701755/611048/f50b749a-cdc5-11e2-80e0-b3a2d7c5be14.png)
![before](https://f.cloud.github.com/assets/1701755/611049/f51f961e-cdc5-11e2-9111-24d91765715c.jpg)
