### PR TITLE
Compact `files_to_load` before checking if it's empty

### DIFF
--- a/lib/spin.rb
+++ b/lib/spin.rb
@@ -106,7 +106,7 @@ module Spin
         else
           file_name.to_s
         end
-      end.reject(&:empty?).uniq
+      end.compact.reject(&:empty?).uniq
     end
 
     def make_files_relative(files_to_load, root_path)


### PR DESCRIPTION
My guard file is setup to run `acceptance/<file>_spec.rb`,
`controllers/<file>_rspec.rb` and `routing/<file>_routing_spec.rb`, when
`<file>` is saved.

Some of my controllers have routing specs, some doesn't. In case they
doesn't spin will raise an error, because it can't invoke `empty?` on
nil.

This patch compmacts the `files_to_load` list, before testing if it's
empty. This fixes the problem described above.
