### PR TITLE
2 layers of SIGINT handling

### DIFF
--- a/lib/spin/logger.rb
+++ b/lib/spin/logger.rb
@@ -1,0 +1,42 @@
+require 'logger'
+require 'forwardable'
+
+module Spin
+  class Logger
+    extend Forwardable
+
+    attr_reader :logger
+    def_delegators :logger, :fatal,
+                            :error,
+                            :warn,
+                            :info,
+                            :debug
+
+    def initialize
+      @logger = ::Logger.new($stdout)
+      @logger.level = level
+      @logger.formatter = formatter
+    end
+
+  private
+
+    def level
+      ::Logger::INFO
+    end
+
+    def formatter
+      proc { |_, _, _, message| "[#{caller}] #{message}\n" }
+    end
+
+    # Returns a "Spin" label for log entries, with color, if supported.
+    def caller
+      name = "Spin"
+      $stdout.isatty ? cyan(name) : name
+    end
+
+    # Uses ANSI escape codes to create cyan-colored output.
+    def cyan(string)
+      "\e[36m#{string}\e[0m"
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -19,7 +19,9 @@ describe "Spin" do
     before do
       write "config/application.rb", "$xxx = 1234"
       write "test/foo_test.rb", "puts $xxx * 2"
-      @default_pushed = "Spinning up test/foo_test.rb\n"
+      @log_label = "[Spin]"
+      @default_pushed = "#{@log_label} Spinning up test/foo_test.rb\n"
+      @preloaded_message = "Preloaded Rails environment in "
     end
 
     it "shows help when no arguments are given" do
@@ -28,14 +30,14 @@ describe "Spin" do
 
     it "can serve and push" do
       served, pushed = serve_and_push("", "test/foo_test.rb")
-      served.should include "Preloaded Rails env in "
+      served.should include @preloaded_message
       served.should include "2468"
       pushed.first.should == @default_pushed
     end
 
     it "can run files without .rb extension" do
       served, pushed = serve_and_push("", "test/foo_test")
-      served.should include "Preloaded Rails env in "
+      served.should include @preloaded_message
       served.should include "2468"
       pushed.first.should == @default_pushed
     end
@@ -43,7 +45,7 @@ describe "Spin" do
     it "can run multiple times" do
       write "test/foo_test.rb", "puts $xxx *= 2"
       served, pushed = serve_and_push("", ["test/foo_test.rb", "test/foo_test.rb", "test/foo_test.rb"])
-      served.should include "Preloaded Rails env in "
+      served.should include @preloaded_message
       served.scan("2468").size.should == 3
       pushed.size.should == 3
       pushed.each{|x| x.should == @default_pushed }
@@ -52,17 +54,17 @@ describe "Spin" do
     it "can run multiple files at once" do
       write "test/bar_test.rb", "puts $xxx / 2"
       served, pushed = serve_and_push("", "test/foo_test.rb test/bar_test.rb")
-      served.should include "Preloaded Rails env in "
+      served.should include @preloaded_message
       served.should include "2468"
       served.should include "617"
-      pushed.first.should == "Spinning up test/foo_test.rb test/bar_test.rb\n"
+      pushed.first.should == "#{@log_label} Spinning up test/foo_test.rb test/bar_test.rb\n"
     end
 
     it "complains when the preloaded file cannot be found" do
       delete "config/application.rb"
       write "test/foo_test.rb", "puts 2468"
       served, pushed = serve_and_push("", "test/foo_test.rb")
-      served.should_not include "Preloaded Rails env in "
+      served.should_not include @preloaded_message
       served.should include "Could not find config/application.rb. Are you running"
       served.should include "2468"
       pushed.first.should == @default_pushed
@@ -118,7 +120,7 @@ describe "Spin" do
 
       it "can --push-results" do
         served, pushed = serve_and_push("--push-results", "test/foo_test.rb")
-        served.should include "Preloaded Rails env in "
+        served.should include @preloaded_message
         served.should_not include "2468"
         pushed.first.should include "2468"
       end
@@ -127,7 +129,7 @@ describe "Spin" do
         write "config/application.rb", "raise"
         write "config/environment.rb", "$xxx = 1234"
         served, pushed = serve_and_push("--preload config/environment.rb", "test/foo_test.rb")
-        served.should include "Preloaded Rails env in "
+        served.should include @preloaded_message
         served.should include "2468"
         pushed.first.should == @default_pushed
       end
@@ -142,7 +144,7 @@ describe "Spin" do
 
       it "ignores -e" do
         served, pushed = serve_and_push("-e", "test/foo_test.rb -e")
-        served.should include "Preloaded Rails env in "
+        served.should include @preloaded_message
         served.should include "2468"
         pushed.first.should == @default_pushed
       end


### PR DESCRIPTION
This adds 2 layers of `SIGINT` handling to Spin sever:
- If the process receiving the `SIGINT` is _not_ the Spin server process, the `SIGINT` is "bubbled up" by exiting.
- If the process receiving the `SIGINT` _is_ the Spin server process, it's first ignored. If a second `SIGINT` is received within the time window (5 seconds), the server exits.

The overall effect of these changes is that when Ctrl+C is pressed, the child process (the test) exits, but leaves the server running.
