### PR TITLE
Prevent multiple test processes from running

### DIFF
--- a/lib/spin/test_process.rb
+++ b/lib/spin/test_process.rb
@@ -1,0 +1,38 @@
+module Spin
+  class TestProcess
+    attr_accessor :pid
+
+    # Use wait(2) to block execution until the test process has finished. When
+    # finished, reset the assigned pid.
+    def wait
+      Process.wait
+      reset_pid
+    end
+
+    # Returns +true+ if the test process is alive. If it's not, +false+ is
+    # returned and the assigned pid is reset.
+    def alive?
+      return if @pid.nil?
+
+      alive = Process.kill(0, @pid) rescue nil
+
+      if (alive == 1)
+        true
+      else
+        reset_pid
+        false
+      end
+    end
+
+    def to_s
+      @pid.to_s
+    end
+
+  private
+
+    # Resets the assigned pid.
+    def reset_pid
+      @pid = nil
+    end
+  end
+end

--- a/lib/spin/test_process.rb
+++ b/lib/spin/test_process.rb
@@ -6,33 +6,16 @@ module Spin
     # finished, reset the assigned pid.
     def wait
       Process.wait
-      reset_pid
+      @pid = nil
     end
 
-    # Returns +true+ if the test process is alive. If it's not, +false+ is
-    # returned and the assigned pid is reset.
+    # Returns +true+ if the test process is alive.
     def alive?
-      return if @pid.nil?
-
-      alive = Process.kill(0, @pid) rescue nil
-
-      if (alive == 1)
-        true
-      else
-        reset_pid
-        false
-      end
+      !@pid.nil?
     end
 
     def to_s
       @pid.to_s
-    end
-
-  private
-
-    # Resets the assigned pid.
-    def reset_pid
-      @pid = nil
     end
   end
 end


### PR DESCRIPTION
This fixes a bug where if Ctrl+\ (`SIGQUIT`) was pressed multiple times, multiple test processes were spawned. This message now appears in the console when this bug is prevented:

```
[Spin] Cannot rerun last tests, test process 2384 still alive
```

Other changes:
- Fix bug where if Ctrl+\ was pressed before any tests pushed, `You have a nil object when you didn't expect it!` exception was raised &mdash; instead, this message now appears:
  
  ```
  [Spin] Cannot rerun last tests, please push a file to Spin server first
  ```
- Add notification for when Spin server is ready:
  
  ```
  [Spin] Ready
  ```
- Consolidate duplicate `Process.wait` calls into one location, end of `Spin.fork_and_run`
