### PR TITLE
Set a custom name for spin serve command

### DIFF
--- a/lib/spin.rb
+++ b/lib/spin.rb
@@ -101,6 +101,7 @@ module Spin
 
     # Called by the Spin server process to store its process pid.
     def set_server_process_pid
+      $0 = 'spin-server'
       @server_process_pid = Process.pid
     end
 


### PR DESCRIPTION
Hi everyone,

First of all thank you very much for this project, it's working great for me. 

So the purpose of this very small change is making easier for external software to check if the `spin serve` is running. Just to give you more context, I have a small vim script to execute tests in different situations like inside a tmux pane or a sub shell. Now, I'd like to `spin push` test files when `spin serve` is running and such a small change can make it easier and cleaner. On the other hand, I don't know if there is another way of knowing the server is running. I tried to look for the open socket but it has a random name in a tmp dir (that I think it's a clean solution).
