### PR TITLE
Banner indentation

### DIFF
--- a/lib/spin/cli.rb
+++ b/lib/spin/cli.rb
@@ -52,7 +52,7 @@ module Spin
       private
 
       def usage
-        <<-USAGE.gsub(/^\s{8}/,"")
+        <<-USAGE.gsub(/^\s{10}/,"")
           Usage: spin serve
                  spin push <file> <file>...
           Spin preloads your Rails environment to speed up your autotest(ish) workflow.


### PR DESCRIPTION
Simple fix for the indentation of the banner.

Before:

```
  Usage: spin serve
         spin push <file> <file>...
  Spin preloads your Rails environment to speed up your autotest(ish) workflow.

Server Options:
    -I, --load-path=DIR:DIR          Appends directory to $LOAD_PATH
        --rspec                      Force the selected test framework to RSpec
        --test-unit                  Force the selected test framework to Test::Unit
    -t, --time                       See total execution time for each test run
        --push-results               Push test results to the push process
        --preload FILE               Preload this file instead of config/application.rb
...
```

After:

```
Usage: spin serve
       spin push <file> <file>...
Spin preloads your Rails environment to speed up your autotest(ish) workflow.

Server Options:
    -I, --load-path=DIR:DIR          Appends directory to $LOAD_PATH
        --rspec                      Force the selected test framework to RSpec
        --test-unit                  Force the selected test framework to Test::Unit
    -t, --time                       See total execution time for each test run
        --push-results               Push test results to the push process
...
```
